### PR TITLE
Small improvements to warnings and mutes templates

### DIFF
--- a/abstracto-modules/moderation/src/main/resources/en_US/command/warnings/warnings_warn_entry_en_US.ftl
+++ b/abstracto-modules/moderation/src/main/resources/en_US/command/warnings/warnings_warn_entry_en_US.ftl
@@ -7,5 +7,5 @@
 <#include "warnings_warn_entry_text">
 <#if warning.warning.decayed>
 <#assign decayDate>${formatDate(warning.warning.decayDate, "yyyy-MM-dd HH:mm:ss zz")}</#assign>
-<#include "warnings_warn_is_decayed">
+ <#include "warnings_warn_is_decayed">
 </#if>

--- a/translations/moderation/src/main/resources/en_US/commands/mute/help/mute_long_help_en_US.ftl
+++ b/translations/moderation/src/main/resources/en_US/commands/mute/help/mute_long_help_en_US.ftl
@@ -1,5 +1,5 @@
 Applies the muted role to the user and logs the mute in the `mutes` post target.
-The user will be automatically un-muted after the time period is over and another un-mute notification will be send to the
+The user will be automatically unmuted after the time period is over and another un-mute notification will be send to the
 `mutes` post target.
 
 <#include "duration_format_help">

--- a/translations/moderation/src/main/resources/en_US/commands/mute/unMute_log_unmuted_user_field_title_en_US.ftl
+++ b/translations/moderation/src/main/resources/en_US/commands/mute/unMute_log_unmuted_user_field_title_en_US.ftl
@@ -1,1 +1,1 @@
-Un-Muted user
+Unmuted user

--- a/translations/moderation/src/main/resources/en_US/commands/warnings/warnings_header_text_en_US.ftl
+++ b/translations/moderation/src/main/resources/en_US/commands/warnings/warnings_header_text_en_US.ftl
@@ -1,1 +1,1 @@
-Amount of warns ${warnCount}.
+Amount of warnings: ${warnCount}.

--- a/translations/moderation/src/main/resources/en_US/commands/warnings/warnings_warn_entry_text_en_US.ftl
+++ b/translations/moderation/src/main/resources/en_US/commands/warnings/warnings_warn_entry_text_en_US.ftl
@@ -1,1 +1,1 @@
-Warning #${warnId} with reason: ${reason} towards user ${warnedUserText} by user ${warningUserText} on `${warnDate}`.
+Warning #${warnId} with reason: `${reason}` towards user ${warnedUserText} by user ${warningUserText} on `${warnDate}`.


### PR DESCRIPTION
- Warning reasons after `;warnings user_id` is run is now displayed in a code block for better readability
- There is now a space before `This warning was decayed on [...]` after running `;warnings user_id`
- Minor wording changes